### PR TITLE
Executable configuration parameter

### DIFF
--- a/lib/vagrant-docker-compose/cap/linux/docker_compose_install.rb
+++ b/lib/vagrant-docker-compose/cap/linux/docker_compose_install.rb
@@ -3,10 +3,10 @@ module VagrantPlugins
     module Cap
       module Linux
         module DockerComposeInstall
-          def self.docker_compose_install(machine)
+          def self.docker_compose_install(machine, config)
             machine.communicate.tap do |comm|
-              comm.sudo("curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-  chmod +x /usr/local/bin/docker-compose")
+              comm.sudo("curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose-`uname -s`-`uname -m` > #{config.executable}
+  chmod +x #{config.executable}")
             end
           end
         end

--- a/lib/vagrant-docker-compose/cap/linux/docker_compose_installed.rb
+++ b/lib/vagrant-docker-compose/cap/linux/docker_compose_installed.rb
@@ -3,9 +3,9 @@ module VagrantPlugins
     module Cap
       module Linux
         module DockerComposeInstalled
-          def self.docker_compose_installed(machine)
+          def self.docker_compose_installed(machine, config)
             paths = [
-              "/usr/local/bin/docker-compose"
+              config.executable
             ]
 
             paths.all? do |p|

--- a/lib/vagrant-docker-compose/config.rb
+++ b/lib/vagrant-docker-compose/config.rb
@@ -1,12 +1,21 @@
 module VagrantPlugins
   module DockerComposeProvisioner
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :yml, :rebuild
+      attr_accessor :yml, :rebuild, :executable
 
       def yml=(yml)
         raise DockerComposeError, :yml_must_be_absolute if !Pathname.new(yml).absolute?
         @yml = yml
       end
+
+      def initialize
+        @executable = UNSET_VALUE
+      end
+
+      def finalize!
+        @executable = '/usr/local/bin/docker-compose' if @executable == UNSET_VALUE
+      end
+
     end
   end
 end

--- a/lib/vagrant-docker-compose/docker_compose.rb
+++ b/lib/vagrant-docker-compose/docker_compose.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       def build
         @machine.ui.detail(I18n.t(:docker_compose_build))
         @machine.communicate.tap do |comm|
-          comm.sudo("docker-compose -f \"#{@config.yml}\" build") do |type, data|
+          comm.sudo("#{@config.executable} -f \"#{@config.yml}\" build") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -20,7 +20,7 @@ module VagrantPlugins
       def rm
         @machine.ui.detail(I18n.t(:docker_compose_rm))
         @machine.communicate.tap do |comm|
-          comm.sudo("docker-compose -f \"#{@config.yml}\" rm --force") do |type, data|
+          comm.sudo("#{@config.executable} -f \"#{@config.yml}\" rm --force") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -29,7 +29,7 @@ module VagrantPlugins
       def up
         @machine.ui.detail(I18n.t(:docker_compose_up))
         @machine.communicate.tap do |comm|
-          comm.sudo("docker-compose -f \"#{@config.yml}\" up -d") do |type, data|
+          comm.sudo("#{@config.executable} -f \"#{@config.yml}\" up -d") do |type, data|
             handle_comm(type, data)
           end
         end

--- a/lib/vagrant-docker-compose/installer.rb
+++ b/lib/vagrant-docker-compose/installer.rb
@@ -1,18 +1,19 @@
 module VagrantPlugins
   module DockerComposeProvisioner
     class Installer
-      def initialize(machine)
+      def initialize(machine, config)
         @machine = machine
+        @config = config
       end
 
       def ensure_installed
         @machine.ui.detail(I18n.t(:checking_installation))
 
-        if !@machine.guest.capability(:docker_compose_installed)
+        if !@machine.guest.capability(:docker_compose_installed, @config)
           @machine.ui.detail(I18n.t(:installing))
-          @machine.guest.capability(:docker_compose_install)
+          @machine.guest.capability(:docker_compose_install, @config)
 
-          if !@machine.guest.capability(:docker_compose_installed)
+          if !@machine.guest.capability(:docker_compose_installed, @config)
             raise DockerComposeError, :install_failed
           end
         end

--- a/lib/vagrant-docker-compose/locales/en.yml
+++ b/lib/vagrant-docker-compose/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   errors:
     yml_must_be_absolute: Docker Compose YML path must be absolute!
+    install_failed: Docker Compose installation failed
   not_supported_on_guest: Not supported on the guest operating system
   checking_installation: Checking for Docker Compose installation...
   installing: Installing Docker Compose

--- a/lib/vagrant-docker-compose/provisioner.rb
+++ b/lib/vagrant-docker-compose/provisioner.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
       def initialize(machine, config, installer = nil, docker_compose = nil)
         super(machine, config)
 
-        @installer = installer || Installer.new(@machine)
+        @installer = installer || Installer.new(@machine, @config)
         @docker_compose = docker_compose || DockerCompose.new(@machine, @config)
       end
 


### PR DESCRIPTION
On EL distributions (CentOS, RHEL, probably Oracle) `/usr/local/bin/` is not in `$PATH` by default, so I added an `executable` configuration parameter (which is still set by default to `/usr/local/bin/docker-compose`).