### PR TITLE
Update Vagrantfile

### DIFF
--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,11 +1,17 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+unless Vagrant.has_plugin?("vagrant-docker-compose")
+        system('vagrant plugin install vagrant-docker-compose')
+        raise("Plugin installed. Run command again.");
+end
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
 
   config.vm.network(:forwarded_port, guest: 8080, host: 8080)
 
+  config.vm.provision :shell, inline: "sudo apt-get update"
   config.vm.provision :docker
   config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, project_name: "myproject", run: "always"
 end

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -2,8 +2,9 @@
 # vi: set ft=ruby :
 
 unless Vagrant.has_plugin?("vagrant-docker-compose")
-        system('vagrant plugin install vagrant-docker-compose')
-        raise("Plugin installed. Run command again.");
+  system("vagrant plugin install vagrant-docker-compose")
+  puts "Dependencies installed, please try the command again."
+  exit
 end
 
 Vagrant.configure("2") do |config|
@@ -11,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.network(:forwarded_port, guest: 8080, host: 8080)
 
-  config.vm.provision :shell, inline: "sudo apt-get update"
+  config.vm.provision :shell, inline: "apt-get update"
   config.vm.provision :docker
   config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, project_name: "myproject", run: "always"
 end


### PR DESCRIPTION
Adding `apt-get update` gets rid of the pesky errors due to failed dependencies on the initial `vagrant up`. Also added a block to install this plugin automatically.