### PR TITLE
update DockerComposeSetProjectName

### DIFF
--- a/lib/vagrant-docker-compose/cap/linux/docker_compose_set_project_name.rb
+++ b/lib/vagrant-docker-compose/cap/linux/docker_compose_set_project_name.rb
@@ -6,7 +6,8 @@ module VagrantPlugins
           def self.docker_compose_set_project_name(machine, config)
             return if config.project_name.nil?
             machine.communicate.tap do |comm|
-              export_command = "echo \"export COMPOSE_PROJECT_NAME='#{config.project_name}'\" >> ~/.profile"
+              export_command = "if grep -q \"COMPOSE_PROJECT_NAME\" ~/.profile;then :; else echo \"export
+COMPOSE_PROJECT_NAME='#{config.project_name}'\" >> ~/.profile;fi"
               comm.execute(export_command)
               comm.sudo(export_command)
             end


### PR DESCRIPTION
The current version spams the ~/.profile file with the COMPOSE_PROJECT_NAME on every vagrant provision. I use a simple check with bash to only add it once. I'm sure you could do it better, but this is what works for me now :)