### PR TITLE
Set `COMPOSE_PROJECT_NAME` in an isolated file.

### DIFF
--- a/lib/vagrant-docker-compose/cap/linux/docker_compose_set_project_name.rb
+++ b/lib/vagrant-docker-compose/cap/linux/docker_compose_set_project_name.rb
@@ -3,12 +3,21 @@ module VagrantPlugins
     module Cap
       module Linux
         module DockerComposeSetProjectName
+          ROOT_PROFILE_FILE_NAME = "~/.profile"
+          PROFILE_FILE_NAME = "~/.profile_vagrant-docker-compose_compose-project-name"
+
           def self.docker_compose_set_project_name(machine, config)
             return if config.project_name.nil?
             machine.communicate.tap do |comm|
-              export_command = "echo \"export COMPOSE_PROJECT_NAME='#{config.project_name}'\" >> ~/.profile"
-              comm.execute(export_command)
-              comm.sudo(export_command)
+              export_command = "export COMPOSE_PROJECT_NAME='#{config.project_name}'"
+              export_injection_command = "echo \"#{export_command}\" > #{PROFILE_FILE_NAME}"
+              comm.execute(export_injection_command)
+              comm.sudo(export_injection_command)
+
+              source_command = "source #{PROFILE_FILE_NAME}"
+              source_injection_command = "if ! grep -q \"#{source_command}\" #{ROOT_PROFILE_FILE_NAME} ; then echo \"#{source_command}\" >> #{ROOT_PROFILE_FILE_NAME} ; fi"
+              comm.execute(source_injection_command)
+              comm.sudo(source_injection_command)
             end
           end
         end


### PR DESCRIPTION
What
=
Set `COMPOSE_PROJECT_NAME` in an isolated file, that gets overwritten
each time in full and is loaded by `~/.profile`.

Why
=
This makes the text being added to `~/.profile` consistent and unchanged
regardless of what the `COMPOSE_PROJECT_NAME` is set to, which means we
can reliably check to see if we've already made the changes we need to
to `~/.profile` even if the project name has changed.