### PR TITLE
Allow arbitrary options to be configured.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ end
 Equivalent to running:
 
 ```bash
-docker-compose -f [yml] up
+docker-compose -f [yml] up -d
 ```
 
 ### To install, rebuild and run docker-compose on `vagrant up`
@@ -52,16 +52,39 @@ end
 Equivalent to running:
 
 ```bash
-docker-compose -f [yml] rm
+docker-compose -f [yml] rm --force
 docker-compose -f [yml] build
-docker-compose -f [yml] up
+docker-compose -f [yml] up -d
 ```
+
+### To install, rebuild and run docker-compose with options on `vagrant up`
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision :docker
+  config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true,
+    options: "--x-networking", command_options: { rm: "", up: "-d --timeout 20"}, run: "always"
+end
+```
+
+Equivalent to running:
+
+```bash
+docker-compose --x-networking -f [yml] rm
+docker-compose --x-networking -f [yml] build
+docker-compose --x-networking -f [yml] up -d --timeout 20
+```
+
 
 ### Other configs
 
 * `compose_version` – defaults to `1.5.0`.
 * `project_name` – compose will default to naming the project `vagrant`.
 * `executable` – the location the executable will be stored, defaults to `/usr/local/bin/docker-compose`.
+* `options` - a `String` that's included as the first arguments when calling the docker-compose executable, you can use this to pass arbitrary options/flags to docker-compose, default to `nil`.
+* `command_options` - a `Hash` of docker-compose commands to options, you can use this to pass arbitrary options/flags to the docker-compose commands, defaults to: `{ rm: "--force", up: "-d" }`.
 
 ## Example
 

--- a/lib/vagrant-docker-compose/config.rb
+++ b/lib/vagrant-docker-compose/config.rb
@@ -1,7 +1,12 @@
 module VagrantPlugins
   module DockerComposeProvisioner
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :yml, :rebuild, :project_name, :executable, :compose_version
+      DEFAULT_COMMAND_OPTIONS = {
+        rm: "--force",
+        up: "-d"
+      }
+
+      attr_accessor :yml, :rebuild, :project_name, :executable, :compose_version, :options, :command_options
 
       def yml=(yml)
         raise DockerComposeError, :yml_must_be_absolute if !Pathname.new(yml).absolute?
@@ -12,12 +17,17 @@ module VagrantPlugins
         @executable = UNSET_VALUE
         @project_name = UNSET_VALUE
         @compose_version = UNSET_VALUE
+        @options = UNSET_VALUE
+        @command_options = UNSET_VALUE
       end
 
       def finalize!
         @executable = "/usr/local/bin/docker-compose" if @executable == UNSET_VALUE
         @project_name = nil if @project_name == UNSET_VALUE
         @compose_version = "1.5.0" if @compose_version == UNSET_VALUE
+        @options = nil if @options == UNSET_VALUE
+        @command_options = {} if @command_options == UNSET_VALUE
+        @command_options = DEFAULT_COMMAND_OPTIONS.merge(@command_options)
       end
     end
   end

--- a/lib/vagrant-docker-compose/docker_compose.rb
+++ b/lib/vagrant-docker-compose/docker_compose.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       def build
         @machine.ui.detail(I18n.t(:docker_compose_build))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable} -f \"#{@config.yml}\" build") do |type, data|
+          comm.sudo("#{@config.executable} #{@config.options} -f \"#{@config.yml}\" build #{@config.command_options[:build]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -20,7 +20,7 @@ module VagrantPlugins
       def rm
         @machine.ui.detail(I18n.t(:docker_compose_rm))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable} -f \"#{@config.yml}\" rm --force") do |type, data|
+          comm.sudo("#{@config.executable} #{@config.options} -f \"#{@config.yml}\" rm #{@config.command_options[:rm]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -29,7 +29,7 @@ module VagrantPlugins
       def up
         @machine.ui.detail(I18n.t(:docker_compose_up))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable} -f \"#{@config.yml}\" up -d") do |type, data|
+          comm.sudo("#{@config.executable} #{@config.options} -f \"#{@config.yml}\" up #{@config.command_options[:up]}") do |type, data|
             handle_comm(type, data)
           end
         end


### PR DESCRIPTION
What
=
Allow arbitrary options to be configured on the `docker-compose` commands.

Why
=
The options/flags available on `docker-compose` are changing rapidly and
allows the user to specify any options without the plugin being kept
up-to-date. Resolves #10.

Inspired by
https://stackoverflow.com/questions/30665816/docker-compose-vagrant-and-insecure-repository?rq=1#comment49395344_30665816