### PR TITLE
Support multiple Compose files (YAML).

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ Equivalent to running:
 docker-compose -f [yml] up -d
 ```
 
+### To install and run docker-compose, with multiple files, on `vagrant up`
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision :docker
+  config.vm.provision :docker_compose,
+    yml: [
+      "/vagrant/docker-compose-base.yml",
+      "/vagrant/docker-compose.yml",
+      ...
+    ],
+    run: "always"
+end
+```
+
+Equivalent to running:
+
+```bash
+docker-compose -f [yml-0] -f [yml-1] ... up -d
+```
+
 ### To install, rebuild and run docker-compose on `vagrant up`
 
 ```ruby
@@ -80,6 +103,7 @@ docker-compose --x-networking -f [yml] up -d --timeout 20
 
 ### Other configs
 
+* `yml` – one or more [Compose files](https://docs.docker.com/compose/compose-file/) (YAML), may be a `String` for a single file, or `Array` for multiple.
 * `compose_version` – defaults to `1.5.0`.
 * `project_name` – compose will default to naming the project `vagrant`.
 * `executable` – the location the executable will be stored, defaults to `/usr/local/bin/docker-compose`.

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -14,5 +14,5 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision :shell, inline: "apt-get update"
   config.vm.provision :docker
-  config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, project_name: "myproject", run: "always"
+  config.vm.provision :docker_compose, yml: ["/vagrant/docker-compose-base.yml","/vagrant/docker-compose.yml"], rebuild: true, project_name: "myproject", run: "always"
 end

--- a/example/docker-compose-base.yml
+++ b/example/docker-compose-base.yml
@@ -1,0 +1,10 @@
+app:
+  build: ./app
+  links:
+    - redis
+  ports:
+    - "8080:8080"
+  volumes:
+    - ./app/:/app/
+redis:
+  image: redis

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,10 +1,3 @@
 app:
-  build: ./app
-  links:
-    - redis
   ports:
-    - "8080:8080"
-  volumes:
-    - ./app/:/app/
-redis:
-  image: redis
+    - "3333:8080"

--- a/lib/vagrant-docker-compose/docker_compose.rb
+++ b/lib/vagrant-docker-compose/docker_compose.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       def build
         @machine.ui.detail(I18n.t(:docker_compose_build))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable} #{@config.options} -f \"#{@config.yml}\" build #{@config.command_options[:build]}") do |type, data|
+          comm.sudo("#{@config.executable} #{@config.options} #{cli_options_for_yml_file} build #{@config.command_options[:build]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -20,7 +20,7 @@ module VagrantPlugins
       def rm
         @machine.ui.detail(I18n.t(:docker_compose_rm))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable} #{@config.options} -f \"#{@config.yml}\" rm #{@config.command_options[:rm]}") do |type, data|
+          comm.sudo("#{@config.executable} #{@config.options} #{cli_options_for_yml_file} rm #{@config.command_options[:rm]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -29,7 +29,7 @@ module VagrantPlugins
       def up
         @machine.ui.detail(I18n.t(:docker_compose_up))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable} #{@config.options} -f \"#{@config.yml}\" up #{@config.command_options[:up]}") do |type, data|
+          comm.sudo("#{@config.executable} #{@config.options} #{cli_options_for_yml_file} up #{@config.command_options[:up]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -44,6 +44,13 @@ module VagrantPlugins
         when :stdout; @machine.ui.detail(data)
         when :stderr; @machine.ui.error(data)
         end
+      end
+
+      private
+
+      def compose_file_cli_options
+        files = @config.yml.is_a?(Array) ? @config.yml : [@config.yml]
+        files.map { |file| "-f \"#{file}\"" }.join(" ")
       end
     end
   end


### PR DESCRIPTION
What
====
Support multiple Compose files (YAML). The `yml` option may now be
specified as an `Array` of `String`s, with each being a file.

Why
====
Issue #21. Docker Compose supports multiple files being given to the
command line for separating configurations into logical parts for
re-use. This is making it possible to use multiple files with this
plugin.