### PR TITLE
Add `env` configuration option to pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ docker-compose --x-networking -f [yml] up -d --timeout 20
 * `yml` – one or more [Compose files](https://docs.docker.com/compose/compose-file/) (YAML), may be a `String` for a single file, or `Array` for multiple.
 * `compose_version` – defaults to `1.6.2`.
 * `project_name` – compose will default to naming the project `vagrant`.
+* `env` – a `Hash` of environment variables to value that are passed to the `docker-compose` commands, defaults to an empty `Hash`.
 * `executable_symlink_path` – the location the executable will be symlinked to, defaults to `/usr/local/bin/docker-compose`.
 * `executable_install_path` – the location the executable will be stored, defaults to `<executable_symlink_path>-<compose_version>`, i.e. `/usr/local/bin/docker-compose-1.5.0`.
 * `options` - a `String` that's included as the first arguments when calling the docker-compose executable, you can use this to pass arbitrary options/flags to docker-compose, default to `nil`.

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -10,10 +10,12 @@ end
 Vagrant.configure("2") do |config|
   config.vm.box = "hashicorp/precise64"
 
-  config.vm.network(:forwarded_port, guest: 8080, host: 8080)
+  port = 9090
+
+  config.vm.network(:forwarded_port, guest: port, host: port)
   config.vm.network(:forwarded_port, guest: 3333, host: 3333)
 
   config.vm.provision :shell, inline: "apt-get update"
   config.vm.provision :docker
-  config.vm.provision :docker_compose, yml: ["/vagrant/docker-compose-base.yml","/vagrant/docker-compose.yml"], rebuild: true, project_name: "myproject", run: "always"
+  config.vm.provision :docker_compose, env: { "PORT" => "#{port}" }, yml: ["/vagrant/docker-compose-base.yml","/vagrant/docker-compose.yml"], rebuild: true, project_name: "myproject", run: "always"
 end

--- a/example/docker-compose-base.yml
+++ b/example/docker-compose-base.yml
@@ -3,7 +3,7 @@ app:
   links:
     - redis
   ports:
-    - "8080:8080"
+    - "${PORT}:8080"
   volumes:
     - ./app/:/app/
 redis:

--- a/lib/vagrant-docker-compose/config.rb
+++ b/lib/vagrant-docker-compose/config.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
         up: "-d"
       }
 
-      attr_accessor :yml, :rebuild, :project_name, :executable_symlink_path, :executable_install_path, :compose_version, :options, :command_options
+      attr_accessor :yml, :rebuild, :project_name, :env, :executable_symlink_path, :executable_install_path, :compose_version, :options, :command_options
 
       def yml=(yml)
         files = yml.is_a?(Array) ? yml : [yml]
@@ -19,6 +19,7 @@ module VagrantPlugins
       def initialize
         @project_name = UNSET_VALUE
         @compose_version = UNSET_VALUE
+        @env = UNSET_VALUE
         @executable_symlink_path = UNSET_VALUE
         @executable_install_path = UNSET_VALUE
         @options = UNSET_VALUE
@@ -28,11 +29,16 @@ module VagrantPlugins
       def finalize!
         @project_name = nil if @project_name == UNSET_VALUE
         @compose_version = "1.6.2" if @compose_version == UNSET_VALUE
+        @env = {} if @env == UNSET_VALUE
         @executable_symlink_path = "/usr/local/bin/docker-compose" if @executable_symlink_path == UNSET_VALUE
         @executable_install_path = "#{@executable_symlink_path}-#{@compose_version}" if @executable_install_path == UNSET_VALUE
         @options = nil if @options == UNSET_VALUE
         @command_options = {} if @command_options == UNSET_VALUE
         @command_options = DEFAULT_COMMAND_OPTIONS.merge(@command_options)
+      end
+
+      def env_s
+        @env.map { |k, v| "#{k}=#{Shellwords.escape(v)}" }.join(" ")
       end
     end
   end

--- a/lib/vagrant-docker-compose/docker_compose.rb
+++ b/lib/vagrant-docker-compose/docker_compose.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       def build
         @machine.ui.detail(I18n.t(:docker_compose_build))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable_install_path} #{@config.options} #{cli_options_for_yml_file} build #{@config.command_options[:build]}") do |type, data|
+          comm.sudo("#{@config.env_s} #{@config.executable_install_path} #{@config.options} #{cli_options_for_yml_file} build #{@config.command_options[:build]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -20,7 +20,7 @@ module VagrantPlugins
       def rm
         @machine.ui.detail(I18n.t(:docker_compose_rm))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable_install_path} #{@config.options} #{cli_options_for_yml_file} rm #{@config.command_options[:rm]}") do |type, data|
+          comm.sudo("#{@config.env_s} #{@config.executable_install_path} #{@config.options} #{cli_options_for_yml_file} rm #{@config.command_options[:rm]}") do |type, data|
             handle_comm(type, data)
           end
         end
@@ -29,7 +29,7 @@ module VagrantPlugins
       def up
         @machine.ui.detail(I18n.t(:docker_compose_up))
         @machine.communicate.tap do |comm|
-          comm.sudo("#{@config.executable_install_path} #{@config.options} #{cli_options_for_yml_file} up #{@config.command_options[:up]}") do |type, data|
+          comm.sudo("#{@config.env_s} #{@config.executable_install_path} #{@config.options} #{cli_options_for_yml_file} up #{@config.command_options[:up]}") do |type, data|
             handle_comm(type, data)
           end
         end


### PR DESCRIPTION
What
===
Add an `env` configuration option, that when set will pass environment
variables to the docker-compose commands that are run.

Why
===
Fixes #33. Allows setting of configurations in the host and passing them through
to the docker-compose.yml as environment variables.