### PR TITLE
Add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  build:
+    machine:
+      image: circleci/classic:latest
+    steps:
+      - checkout
+      - run: bundle install --path vendor/bundle
+      - run: docker build -t vagrant git@github.com:leighmcculloch/vagrant-docker-image
+      - run: bundle exec vagrant up
+      - run: bundle exec vagrant ssh -c 'docker-compose --version'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vagrant Provisioner: Docker Compose
 
+![CircleCI](https://img.shields.io/circleci/build/github/leighmcculloch/vagrant-docker-compose?style=for-the-badge)
+
 A Vagrant provisioner for [Docker Compose](https://docs.docker.com/compose/). Installs Docker Compose and can also bring up the containers defined by a [docker-compose.yml](https://docs.docker.com/compose/yml/).
 
 ## Install


### PR DESCRIPTION
### What

Add CI test run that checks that the plugin can install `docker-compose`.

### Why

The project has no tests. This test makes sure that the first task it performs, installing `docker-compose` works. This can set the foundation for additional tests.