### PR TITLE
Update build location for vagrant image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,6 @@ jobs:
     steps:
       - checkout
       - run: bundle install --path vendor/bundle
-      - run: docker build -t vagrant git@github.com:leighmcculloch/vagrant-docker-image
+      - run: docker build -t vagrant https://github.com/leighmcculloch/vagrant-docker-image.git#:debian10
       - run: bundle exec vagrant up
       - run: bundle exec vagrant ssh -c 'docker-compose --version'


### PR DESCRIPTION
### What
Update build location for vagrant image to get the Debian image from the `debian10` subdirectory and use `https` instead of `ssh`.

### Why
In leighmcculloch/vagrant-docker-image@a783f5c812bddbe8f2e8dc08a210614485e7c02b the Debian image was moved into a sub-directory. I also realized using `ssh` was inconvenient because when I was on a machine without an ssh key it failed and it's unnecessary to use ssh, https works fine.